### PR TITLE
LCD Initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .cproject
 .project
 /Debug/
+/Verbose Debug/

--- a/include/lcd.h
+++ b/include/lcd.h
@@ -9,6 +9,13 @@
 #define LCD_DISABLE (0x0)
 #define LCD_COMMAND (0x0)
 #define LCD_DATA (0x40)
+#define LCD_MOVE_CURSOR_CMD (0x80)
+#define LCD_CLEAR_CMD (0x1)
+#define LCD_FIRST_ROW_OFFSET (0x0)
+#define LCD_SECOND_ROW_OFFSET (0x40)
+#define CHAR_OMEGA (0xF4)
+#define DELAY_PRESCALER_1KHZ (47999) /* 48 MHz / (47999 + 1) = 1 kHz */
+#define DELAY_RELOAD_PERIOD (100) /* 100 ms */
 
 // Initializes the LCD from a fresh power-on state on the PBMCUSLK.
 // It's a 2x8 character LCD with its input buffered by a shift register.
@@ -27,12 +34,29 @@ void myGPIOB_Init(void);
 // Use SPI in master mode, 8b data out.
 void mySPI_Init(void);
 
+// Configures TIM3 for use as a delay timer
+void DELAY_Init(void);
+
 // Send data to the shift register via SPI
 void HC595_Write(uint8_t word);
 
 // Write 8b word to an LCD configured for 4b input using shift register
 // @param type: Can be LCD_COMMAND or LCD_DATA
 void LCD_SendWord(uint8_t type, uint8_t word);
+
+// Convenience variant of LCD_SendWord that accepts ASCII words
+// @param character: A single character e.g. "H"
+void LCD_SendASCIIChar(char* character);
+
+// Convenience variant of LCD_SendWord that prints single digits 0:9
+// @param digit: An int, 0:9
+void LCD_SendDigit(uint8_t digit);
+
+// Clears the LCD and injects a 2ms delay to allow the LCD to finish the operation
+void LCD_Clear(void);
+
+// Execute empty loop for specified time in ms
+void DELAY_Set(uint32_t milliseconds);
 
 // True if SPI can accept data to send
 // @return: False / True as 0 / 1
@@ -41,5 +65,8 @@ uint8_t SPI_ReadyToSend(void);
 // True if the SPI is not in use
 // @return: False / True as 0 / 1
 uint8_t SPI_DoneSending(void);
+
+// Positions the LCD cursor at row x [1,2] col y [1:8]
+void LCD_MoveCursor(uint8_t row, uint8_t col);
 
 #endif /* __LCD_H */

--- a/include/lcd.h
+++ b/include/lcd.h
@@ -1,0 +1,42 @@
+#ifndef __LCD_H
+#define __LCD_H
+
+// Maps to EN and R/S bits for LCD
+#define LCD_ENABLE (0x80)
+#define LCD_DISABLE (0x0)
+#define LCD_COMMAND (0x0)
+#define LCD_DATA (0x40)
+
+// Initializes the LCD from a fresh power-on state on the PBMCUSLK.
+// It's a 2x8 character LCD with its input buffered by a shift register.
+// The LCD is set to auto-increment and use 4bit data mode.
+// Configures:
+//   - GPIOB
+//   - SPI
+void LCD_Init(void);
+
+// Turns on GPIOB so it can be used by SPI.
+//  PB3 -> MOSI (Master Out Slave In)
+//  PB4 -> LCK  (Load clock)
+//  PB5 -> SCK  (Shift clock)
+void myGPIOB_Init(void);
+
+// Use SPI in master mode, 8b data out.
+void mySPI_Init(void);
+
+// Send data to the shift register via SPI
+void HC595_Write(uint8_t word);
+
+// Write 8b word to an LCD configured for 4b input using shift register
+// @param type: Can be HC595_COMMAND or HC595_DATA
+void LCD_SendWord(uint8_t type, uint8_t word);
+
+// True if SPI can accept data to send
+// @return: False / True as 0 / 1
+uint8_t SPI_ReadyToSend(void);
+
+// True if the SPI is not in use
+// @return: False / True as 0 / 1
+uint8_t SPI_DoneSending(void);
+
+#endif /* __LCD_H */

--- a/include/lcd.h
+++ b/include/lcd.h
@@ -1,7 +1,10 @@
 #ifndef __LCD_H
 #define __LCD_H
 
-// Maps to EN and R/S bits for LCD
+// Pin configuration, must be on GPIOB
+#define LCD_LCK_PIN (GPIO_Pin_4)
+
+// Maps to EN and RS bits for LCD
 #define LCD_ENABLE (0x80)
 #define LCD_DISABLE (0x0)
 #define LCD_COMMAND (0x0)

--- a/include/lcd.h
+++ b/include/lcd.h
@@ -28,7 +28,7 @@ void mySPI_Init(void);
 void HC595_Write(uint8_t word);
 
 // Write 8b word to an LCD configured for 4b input using shift register
-// @param type: Can be HC595_COMMAND or HC595_DATA
+// @param type: Can be LCD_COMMAND or LCD_DATA
 void LCD_SendWord(uint8_t type, uint8_t word);
 
 // True if SPI can accept data to send

--- a/src/lcd.c
+++ b/src/lcd.c
@@ -1,0 +1,146 @@
+#include "stm32f0xx_gpio.h"
+#include "stm32f0xx_rcc.h"
+#include "stm32f0xx_spi.h"
+#include "cmsis/cmsis_device.h"
+#include "diag/Trace.h"
+#include "lcd.h"
+
+#define LCD_ENABLE (0x80)
+#define LCD_DISABLE (0x0)
+#define LCD_COMMAND (0x0)
+#define LCD_DATA (0x40)
+
+void LCD_Init(void){
+	// Configure GPIOB to control LCD via SPI
+	myGPIOB_Init();
+	mySPI_Init();
+
+	// Configure the internal LCD controls
+	// PBMCUSLK has a shift register connected to the LCD like:
+	//    Q7  Q6  Q5  Q4  |  Q3  Q2  Q1  Q0
+	//    =================================
+	//    EN  R/S NC  NC  |  D7  D6  D5  D4
+	// When the LCD is initialized it's working in 8bit word mode.
+	// The PBMCUSLK will interpret the 8bit word sent by SPI according to
+	// the above diagram and D3->D0 = 0. The first thing we have to do is
+	// shift into 4b mode operation so we can ignore D3->D0.
+	// We can't use our regular write command / data functions since they're
+	// written with the assumption we're in 4b mode.
+	uint8_t set4bMode = 0x2;
+	HC595_Write(LCD_DISABLE | LCD_COMMAND | set4bMode);
+	HC595_Write(LCD_ENABLE | LCD_COMMAND | set4bMode);
+	HC595_Write(LCD_DISABLE | LCD_COMMAND | set4bMode);
+
+	// Now do the rest of the LCD config
+	// 4 bits, 2 lines, 5x7 font
+	LCD_SendWord(LCD_COMMAND, 0x28);
+
+	// Display ON, No cursors
+	LCD_SendWord(LCD_COMMAND, 0x0E);
+
+	// Entry mode: Increment, No Display shifting
+	LCD_SendWord(LCD_COMMAND, 0x06);
+
+	// Clear display
+	LCD_SendWord(LCD_COMMAND, 0x01);
+
+	// Write the initial units and resistance / freq placeholders manually instead
+	// of trying to pass non-int values through the number printing functions
+	//  ?.?    Ω
+	//  ?.?    H
+	// TODO: Ω and H are static, so draw them in place
+}
+
+void myGPIOB_Init(void){
+	// Turn on the GPIOB clock
+	RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOB, ENABLE);
+
+	// PB3 --AF0-> SPI MOSI
+	// PB5 --AF0-> SPI SCK
+	GPIO_InitTypeDef GPIO_InitStruct;
+	GPIO_InitStruct.GPIO_Pin   = GPIO_Pin_3 | GPIO_Pin_5;
+	GPIO_InitStruct.GPIO_Mode  = GPIO_Mode_AF;
+	GPIO_InitStruct.GPIO_Speed = GPIO_Speed_50MHz;
+	GPIO_InitStruct.GPIO_OType = GPIO_OType_PP;
+	GPIO_InitStruct.GPIO_PuPd  = GPIO_PuPd_NOPULL;
+	GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+	// PB4 will be manually toggled to control the output update on the shift register.
+	// This will expose the contents of the register to the LCD controller.
+	GPIO_InitStruct.GPIO_Pin   = GPIO_Pin_4;
+	GPIO_InitStruct.GPIO_Mode  = GPIO_Mode_OUT;
+	GPIO_InitStruct.GPIO_Speed = GPIO_Speed_50MHz;
+	GPIO_InitStruct.GPIO_OType = GPIO_OType_PP;
+	GPIO_InitStruct.GPIO_PuPd  = GPIO_PuPd_NOPULL;
+	GPIO_Init(GPIOB, &GPIO_InitStruct);
+}
+
+void mySPI_Init(void){
+	// Turn on the SPI clock
+	RCC_APB2PeriphClockCmd(RCC_APB2Periph_SPI1 , ENABLE);
+
+	SPI_InitTypeDef SPI_InitStruct;
+	SPI_InitStruct.SPI_Direction 		 = SPI_Direction_1Line_Tx;
+	SPI_InitStruct.SPI_Mode 			 = SPI_Mode_Master;
+	SPI_InitStruct.SPI_DataSize 		 = SPI_DataSize_8b;
+	SPI_InitStruct.SPI_CPOL 			 = SPI_CPOL_Low;
+	SPI_InitStruct.SPI_CPHA 			 = SPI_CPHA_1Edge;
+	SPI_InitStruct.SPI_NSS				 = SPI_NSS_Soft;
+	SPI_InitStruct.SPI_BaudRatePrescaler = SPI_BaudRatePrescaler_256 ;
+	SPI_InitStruct.SPI_FirstBit 		 = SPI_FirstBit_MSB;
+	SPI_InitStruct.SPI_CRCPolynomial 	 = 7;
+
+	SPI_Init(SPI1, &SPI_InitStruct);
+	SPI_Cmd(SPI1, ENABLE);
+}
+
+void HC595_Write(uint8_t word){
+	// We only want to expose the register values to the LCD once the new word
+	// has loaded completely. We do this by toggling LCK, which controls whether
+	// or not the register output tracks its current contents
+
+	// Don't update the register output; LCK = 0
+	GPIOB->BRR = GPIO_Pin_4;
+
+	// Poll SPI until its ready to receive more data
+	while(!SPI_ReadyToSend()) {};
+
+	SPI_SendData8(SPI1, word);
+
+	// Poll SPI to determine when it's finished transmitting
+	while(!SPI_DoneSending()) {};
+
+	// Update the output; LCK = 1
+	GPIOB->BSRR = GPIO_Pin_4;
+}
+
+uint8_t SPI_ReadyToSend(void){
+	// SPI can accept more data into its TX queue if TXE = 1 OR BSY = 0
+	return (
+		(SPI_I2S_GetFlagStatus(SPI1, SPI_I2S_FLAG_TXE) == SET) ||
+		(SPI_I2S_GetFlagStatus(SPI1, SPI_I2S_FLAG_BSY) == RESET)
+	);
+}
+
+uint8_t SPI_DoneSending(void){
+	// SPI is done sending when BSY = 0
+	return (SPI_I2S_GetFlagStatus(SPI1, SPI_I2S_FLAG_BSY) == RESET);
+}
+
+void LCD_SendWord(uint8_t type, uint8_t word){
+	// The high half of the register output is always reserved for EN and R/S.
+	// To send an 8b target word we have to send it as two sequential 4b half-words,
+	// with the target half-words occupying the lower half of the word.
+
+	uint8_t high = ((word & 0xF0) >> 4);
+	uint8_t low = word & 0x0F;
+
+	HC595_Write(LCD_DISABLE | type | high);
+	HC595_Write(LCD_ENABLE | type | high);
+	HC595_Write(LCD_DISABLE | type | high);
+
+	HC595_Write(LCD_DISABLE | type | low);
+	HC595_Write(LCD_ENABLE | type | low);
+	HC595_Write(LCD_DISABLE | type | low);
+}
+

--- a/src/lcd.c
+++ b/src/lcd.c
@@ -5,142 +5,137 @@
 #include "diag/Trace.h"
 #include "lcd.h"
 
-#define LCD_ENABLE (0x80)
-#define LCD_DISABLE (0x0)
-#define LCD_COMMAND (0x0)
-#define LCD_DATA (0x40)
-
 void LCD_Init(void){
-	// Configure GPIOB to control LCD via SPI
-	myGPIOB_Init();
-	mySPI_Init();
+    // Configure GPIOB to control LCD via SPI
+    myGPIOB_Init();
+    mySPI_Init();
 
-	// Configure the internal LCD controls
-	// PBMCUSLK has a shift register connected to the LCD like:
-	//    Q7  Q6  Q5  Q4  |  Q3  Q2  Q1  Q0
-	//    =================================
-	//    EN  R/S NC  NC  |  D7  D6  D5  D4
-	// When the LCD is initialized it's working in 8bit word mode.
-	// The PBMCUSLK will interpret the 8bit word sent by SPI according to
-	// the above diagram and D3->D0 = 0. The first thing we have to do is
-	// shift into 4b mode operation so we can ignore D3->D0.
-	// We can't use our regular write command / data functions since they're
-	// written with the assumption we're in 4b mode.
-	uint8_t set4bMode = 0x2;
-	HC595_Write(LCD_DISABLE | LCD_COMMAND | set4bMode);
-	HC595_Write(LCD_ENABLE | LCD_COMMAND | set4bMode);
-	HC595_Write(LCD_DISABLE | LCD_COMMAND | set4bMode);
+    // Configure the internal LCD controls
+    // PBMCUSLK has a shift register connected to the LCD like:
+    //    Q7  Q6  Q5  Q4  |  Q3  Q2  Q1  Q0
+    //    =================================
+    //    EN  R/S NC  NC  |  D7  D6  D5  D4
+    // When the LCD is initialized it's working in 8bit word mode.
+    // The PBMCUSLK will interpret the 8bit word sent by SPI according to
+    // the above diagram and D3->D0 = 0. The first thing we have to do is
+    // shift into 4b mode operation so we can ignore D3->D0.
+    // We can't use LCD_SendWord now since it's written with the assumption
+    // we're in 4b mode.
+    uint8_t set4bMode = 0x2;
+    HC595_Write(LCD_DISABLE | LCD_COMMAND | set4bMode);
+    HC595_Write(LCD_ENABLE | LCD_COMMAND | set4bMode);
+    HC595_Write(LCD_DISABLE | LCD_COMMAND | set4bMode);
 
-	// Now do the rest of the LCD config
-	// 4 bits, 2 lines, 5x7 font
-	LCD_SendWord(LCD_COMMAND, 0x28);
+    // Now do the rest of the LCD config
+    // 4 bits, 2 lines, 5x7 font
+    LCD_SendWord(LCD_COMMAND, 0x28);
 
-	// Display ON, No cursors
-	LCD_SendWord(LCD_COMMAND, 0x0E);
+    // Display ON, No cursors
+    LCD_SendWord(LCD_COMMAND, 0x0E);
 
-	// Entry mode: Increment, No Display shifting
-	LCD_SendWord(LCD_COMMAND, 0x06);
+    // Entry mode: Increment, No Display shifting
+    LCD_SendWord(LCD_COMMAND, 0x06);
 
-	// Clear display
-	LCD_SendWord(LCD_COMMAND, 0x01);
+    // Clear display
+    LCD_SendWord(LCD_COMMAND, 0x01);
 
-	// Write the initial units and resistance / freq placeholders manually instead
-	// of trying to pass non-int values through the number printing functions
-	//  ?.?    Ω
-	//  ?.?    H
-	// TODO: Ω and H are static, so draw them in place
+    // Write the initial units and resistance / freq placeholders manually instead
+    // of trying to pass non-int values through the number printing functions
+    //  ?.?    Ω
+    //  ?.?    H
+    // TODO: Ω and H are static, so draw them in place
 }
 
 void myGPIOB_Init(void){
-	// Turn on the GPIOB clock
-	RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOB, ENABLE);
+    // Turn on the GPIOB clock
+    RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOB, ENABLE);
 
-	// PB3 --AF0-> SPI MOSI
-	// PB5 --AF0-> SPI SCK
-	GPIO_InitTypeDef GPIO_InitStruct;
-	GPIO_InitStruct.GPIO_Pin   = GPIO_Pin_3 | GPIO_Pin_5;
-	GPIO_InitStruct.GPIO_Mode  = GPIO_Mode_AF;
-	GPIO_InitStruct.GPIO_Speed = GPIO_Speed_50MHz;
-	GPIO_InitStruct.GPIO_OType = GPIO_OType_PP;
-	GPIO_InitStruct.GPIO_PuPd  = GPIO_PuPd_NOPULL;
-	GPIO_Init(GPIOB, &GPIO_InitStruct);
+    // PB3 --AF0-> SPI MOSI
+    // PB5 --AF0-> SPI SCK
+    GPIO_InitTypeDef GPIO_InitStruct;
+    GPIO_InitStruct.GPIO_Pin = GPIO_Pin_3 | GPIO_Pin_5;
+    GPIO_InitStruct.GPIO_Mode = GPIO_Mode_AF;
+    GPIO_InitStruct.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_InitStruct.GPIO_OType = GPIO_OType_PP;
+    GPIO_InitStruct.GPIO_PuPd = GPIO_PuPd_NOPULL;
+    GPIO_Init(GPIOB, &GPIO_InitStruct);
 
-	// PB4 will be manually toggled to control the output update on the shift register.
-	// This will expose the contents of the register to the LCD controller.
-	GPIO_InitStruct.GPIO_Pin   = GPIO_Pin_4;
-	GPIO_InitStruct.GPIO_Mode  = GPIO_Mode_OUT;
-	GPIO_InitStruct.GPIO_Speed = GPIO_Speed_50MHz;
-	GPIO_InitStruct.GPIO_OType = GPIO_OType_PP;
-	GPIO_InitStruct.GPIO_PuPd  = GPIO_PuPd_NOPULL;
-	GPIO_Init(GPIOB, &GPIO_InitStruct);
+    // PB4 will be manually toggled to control the output update on the shift register.
+    // This will expose the contents of the register to the LCD controller.
+    GPIO_InitStruct.GPIO_Pin = GPIO_Pin_4;
+    GPIO_InitStruct.GPIO_Mode = GPIO_Mode_OUT;
+    GPIO_InitStruct.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_InitStruct.GPIO_OType = GPIO_OType_PP;
+    GPIO_InitStruct.GPIO_PuPd = GPIO_PuPd_NOPULL;
+    GPIO_Init(GPIOB, &GPIO_InitStruct);
 }
 
 void mySPI_Init(void){
-	// Turn on the SPI clock
-	RCC_APB2PeriphClockCmd(RCC_APB2Periph_SPI1 , ENABLE);
+    // Turn on the SPI clock
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_SPI1, ENABLE);
 
-	SPI_InitTypeDef SPI_InitStruct;
-	SPI_InitStruct.SPI_Direction 		 = SPI_Direction_1Line_Tx;
-	SPI_InitStruct.SPI_Mode 			 = SPI_Mode_Master;
-	SPI_InitStruct.SPI_DataSize 		 = SPI_DataSize_8b;
-	SPI_InitStruct.SPI_CPOL 			 = SPI_CPOL_Low;
-	SPI_InitStruct.SPI_CPHA 			 = SPI_CPHA_1Edge;
-	SPI_InitStruct.SPI_NSS				 = SPI_NSS_Soft;
-	SPI_InitStruct.SPI_BaudRatePrescaler = SPI_BaudRatePrescaler_256 ;
-	SPI_InitStruct.SPI_FirstBit 		 = SPI_FirstBit_MSB;
-	SPI_InitStruct.SPI_CRCPolynomial 	 = 7;
+    SPI_InitTypeDef SPI_InitStruct;
+    SPI_InitStruct.SPI_Direction = SPI_Direction_1Line_Tx;
+    SPI_InitStruct.SPI_Mode = SPI_Mode_Master;
+    SPI_InitStruct.SPI_DataSize = SPI_DataSize_8b;
+    SPI_InitStruct.SPI_CPOL = SPI_CPOL_Low;
+    SPI_InitStruct.SPI_CPHA = SPI_CPHA_1Edge;
+    SPI_InitStruct.SPI_NSS = SPI_NSS_Soft;
+    SPI_InitStruct.SPI_BaudRatePrescaler = SPI_BaudRatePrescaler_256;
+    SPI_InitStruct.SPI_FirstBit = SPI_FirstBit_MSB;
+    SPI_InitStruct.SPI_CRCPolynomial = 7;
 
-	SPI_Init(SPI1, &SPI_InitStruct);
-	SPI_Cmd(SPI1, ENABLE);
+    SPI_Init(SPI1, &SPI_InitStruct);
+    SPI_Cmd(SPI1, ENABLE);
 }
 
 void HC595_Write(uint8_t word){
-	// We only want to expose the register values to the LCD once the new word
-	// has loaded completely. We do this by toggling LCK, which controls whether
-	// or not the register output tracks its current contents
+    // We only want to expose the register values to the LCD once the new word
+    // has loaded completely. We do this by toggling LCK, which controls whether
+    // or not the register output tracks its current contents
 
-	// Don't update the register output; LCK = 0
-	GPIOB->BRR = GPIO_Pin_4;
+    // Don't update the register output; LCK = 0
+    GPIOB->BRR = GPIO_Pin_4;
 
-	// Poll SPI until its ready to receive more data
-	while(!SPI_ReadyToSend()) {};
+    // Poll SPI until its ready to receive more data
+    while (!SPI_ReadyToSend()) {
+    };
 
-	SPI_SendData8(SPI1, word);
+    SPI_SendData8(SPI1, word);
 
-	// Poll SPI to determine when it's finished transmitting
-	while(!SPI_DoneSending()) {};
+    // Poll SPI to determine when it's finished transmitting
+    while (!SPI_DoneSending()) {
+    };
 
-	// Update the output; LCK = 1
-	GPIOB->BSRR = GPIO_Pin_4;
+    // Update the output; LCK = 1
+    GPIOB->BSRR = GPIO_Pin_4;
 }
 
 uint8_t SPI_ReadyToSend(void){
-	// SPI can accept more data into its TX queue if TXE = 1 OR BSY = 0
-	return (
-		(SPI_I2S_GetFlagStatus(SPI1, SPI_I2S_FLAG_TXE) == SET) ||
-		(SPI_I2S_GetFlagStatus(SPI1, SPI_I2S_FLAG_BSY) == RESET)
-	);
+    // SPI can accept more data into its TX queue if TXE = 1 OR BSY = 0
+    return ((SPI_I2S_GetFlagStatus(SPI1, SPI_I2S_FLAG_TXE) == SET)
+            || (SPI_I2S_GetFlagStatus(SPI1, SPI_I2S_FLAG_BSY) == RESET));
 }
 
 uint8_t SPI_DoneSending(void){
-	// SPI is done sending when BSY = 0
-	return (SPI_I2S_GetFlagStatus(SPI1, SPI_I2S_FLAG_BSY) == RESET);
+    // SPI is done sending when BSY = 0
+    return (SPI_I2S_GetFlagStatus(SPI1, SPI_I2S_FLAG_BSY) == RESET);
 }
 
 void LCD_SendWord(uint8_t type, uint8_t word){
-	// The high half of the register output is always reserved for EN and R/S.
-	// To send an 8b target word we have to send it as two sequential 4b half-words,
-	// with the target half-words occupying the lower half of the word.
+    // The high half of the register output is always reserved for EN and R/S.
+    // To send an 8b target word we have to send it as two sequential 4b half-words,
+    // with the target half-words occupying the lower half of the word.
 
-	uint8_t high = ((word & 0xF0) >> 4);
-	uint8_t low = word & 0x0F;
+    uint8_t high = ((word & 0xF0) >> 4);
+    uint8_t low = word & 0x0F;
 
-	HC595_Write(LCD_DISABLE | type | high);
-	HC595_Write(LCD_ENABLE | type | high);
-	HC595_Write(LCD_DISABLE | type | high);
+    HC595_Write(LCD_DISABLE | type | high);
+    HC595_Write(LCD_ENABLE | type | high);
+    HC595_Write(LCD_DISABLE | type | high);
 
-	HC595_Write(LCD_DISABLE | type | low);
-	HC595_Write(LCD_ENABLE | type | low);
-	HC595_Write(LCD_DISABLE | type | low);
+    HC595_Write(LCD_DISABLE | type | low);
+    HC595_Write(LCD_ENABLE | type | low);
+    HC595_Write(LCD_DISABLE | type | low);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include "diag/Trace.h"
 #include "cmsis/cmsis_device.h"
+#include "lcd.h"
 
 // ----------------------------------------------------------------------------
 //
@@ -56,6 +57,7 @@ main(int argc, char* argv[])
 	myGPIOA_Init();		/* Initialize I/O port PA */
 	myTIM2_Init();		/* Initialize timer TIM2 */
 	myEXTI_Init();		/* Initialize EXTI */
+	LCD_Init();
 
 	while (1)
 	{

--- a/src/main.c
+++ b/src/main.c
@@ -37,7 +37,6 @@
 #pragma GCC diagnostic ignored "-Wmissing-declarations"
 #pragma GCC diagnostic ignored "-Wreturn-type"
 
-
 /* Clock prescaler for TIM2 timer: no prescaling */
 #define myTIM2_PRESCALER ((uint16_t)0x0000)
 /* Maximum possible setting for overflow */
@@ -50,148 +49,138 @@ void myEXTI_Init(void);
 int
 main(int argc, char* argv[])
 {
+    trace_printf("This is Part 2 of Introductory Lab...\n");
+    trace_printf("System clock: %u Hz\n", SystemCoreClock);
 
-	trace_printf("This is Part 2 of Introductory Lab...\n");
-	trace_printf("System clock: %u Hz\n", SystemCoreClock);
+    myGPIOA_Init(); /* Initialize I/O port PA */
+    myTIM2_Init(); /* Initialize timer TIM2 */
+    myEXTI_Init(); /* Initialize EXTI */
+    LCD_Init();
 
-	myGPIOA_Init();		/* Initialize I/O port PA */
-	myTIM2_Init();		/* Initialize timer TIM2 */
-	myEXTI_Init();		/* Initialize EXTI */
-	LCD_Init();
+    while (1) {
+        // Nothing is going on here...
+    }
 
-	while (1)
-	{
-		// Nothing is going on here...
-	}
-
-	return 0;
+    return 0;
 
 }
-
 
 void myGPIOA_Init()
 {
-	/* Enable clock for GPIOA peripheral */
-	// Relevant register: RCC->AHBENR
-	RCC->AHBENR |= RCC_AHBENR_GPIOAEN;
+    /* Enable clock for GPIOA peripheral */
+    // Relevant register: RCC->AHBENR
+    RCC->AHBENR |= RCC_AHBENR_GPIOAEN;
 
-	/* Configure PA1 as input */
-	// Relevant register: GPIOA->MODER
-	GPIOA->MODER &= ~(GPIO_MODER_MODER1);
+    /* Configure PA1 as input */
+    // Relevant register: GPIOA->MODER
+    GPIOA->MODER &= ~(GPIO_MODER_MODER1);
 
-	/* Ensure no pull-up/pull-down for PA1 */
-	// Relevant register: GPIOA->PUPDR
-	GPIOA->PUPDR &= ~(GPIO_PUPDR_PUPDR1);
+    /* Ensure no pull-up/pull-down for PA1 */
+    // Relevant register: GPIOA->PUPDR
+    GPIOA->PUPDR &= ~(GPIO_PUPDR_PUPDR1);
 }
-
 
 void myTIM2_Init()
 {
-	/* Enable clock for TIM2 peripheral */
-	// Relevant register: RCC->APB1ENR
-	RCC->APB1ENR |= RCC_APB1ENR_TIM2EN;
+    /* Enable clock for TIM2 peripheral */
+    // Relevant register: RCC->APB1ENR
+    RCC->APB1ENR |= RCC_APB1ENR_TIM2EN;
 
-	/* Configure TIM2: buffer auto-reload, count up, stop on overflow,
-	 * enable update events, interrupt on overflow only */
-	// Relevant register: TIM2->CR1
-	TIM2->CR1 = ((uint16_t)0x008C);
+    /* Configure TIM2: buffer auto-reload, count up, stop on overflow,
+     * enable update events, interrupt on overflow only */
+    // Relevant register: TIM2->CR1
+    TIM2->CR1 = ((uint16_t) 0x008C);
 
-	/* Set clock prescaler value */
-	TIM2->PSC = myTIM2_PRESCALER;
-	/* Set auto-reloaded delay */
-	TIM2->ARR = myTIM2_PERIOD;
+    /* Set clock prescaler value */
+    TIM2->PSC = myTIM2_PRESCALER;
+    /* Set auto-reloaded delay */
+    TIM2->ARR = myTIM2_PERIOD;
 
-	/* Update timer registers */
-	// Relevant register: TIM2->EGR
-	TIM2->EGR = ((uint16_t)0x0001);
+    /* Update timer registers */
+    // Relevant register: TIM2->EGR
+    TIM2->EGR = ((uint16_t) 0x0001);
 
-	/* Assign TIM2 interrupt priority = 0 in NVIC */
-	// Relevant register: NVIC->IP[3], or use NVIC_SetPriority
-	NVIC_SetPriority(TIM2_IRQn, 0);
+    /* Assign TIM2 interrupt priority = 0 in NVIC */
+    // Relevant register: NVIC->IP[3], or use NVIC_SetPriority
+    NVIC_SetPriority(TIM2_IRQn, 0);
 
-	/* Enable TIM2 interrupts in NVIC */
-	// Relevant register: NVIC->ISER[0], or use NVIC_EnableIRQ
-	NVIC_EnableIRQ(TIM2_IRQn);
+    /* Enable TIM2 interrupts in NVIC */
+    // Relevant register: NVIC->ISER[0], or use NVIC_EnableIRQ
+    NVIC_EnableIRQ(TIM2_IRQn);
 
-	/* Enable update interrupt generation */
-	// Relevant register: TIM2->DIER
-	TIM2->DIER |= TIM_DIER_UIE;
+    /* Enable update interrupt generation */
+    // Relevant register: TIM2->DIER
+    TIM2->DIER |= TIM_DIER_UIE;
 }
-
 
 void myEXTI_Init()
 {
-	/* Map EXTI1 line to PA1 */
-	// Relevant register: SYSCFG->EXTICR[0]
-	SYSCFG->EXTICR[0] = SYSCFG_EXTICR1_EXTI1_PA;
+    /* Map EXTI1 line to PA1 */
+    // Relevant register: SYSCFG->EXTICR[0]
+    SYSCFG->EXTICR[0] = SYSCFG_EXTICR1_EXTI1_PA;
 
-	/* EXTI1 line interrupts: set rising-edge trigger */
-	// Relevant register: EXTI->RTSR
-	EXTI->RTSR |= EXTI_RTSR_TR1;
+    /* EXTI1 line interrupts: set rising-edge trigger */
+    // Relevant register: EXTI->RTSR
+    EXTI->RTSR |= EXTI_RTSR_TR1;
 
-	/* Unmask interrupts from EXTI1 line */
-	// Relevant register: EXTI->IMR
-	EXTI->IMR |= EXTI_IMR_MR1;
+    /* Unmask interrupts from EXTI1 line */
+    // Relevant register: EXTI->IMR
+    EXTI->IMR |= EXTI_IMR_MR1;
 
-	/* Assign EXTI1 interrupt priority = 0 in NVIC */
-	// Relevant register: NVIC->IP[1], or use NVIC_SetPriority
-	NVIC_SetPriority(EXTI0_1_IRQn, 0);
+    /* Assign EXTI1 interrupt priority = 0 in NVIC */
+    // Relevant register: NVIC->IP[1], or use NVIC_SetPriority
+    NVIC_SetPriority(EXTI0_1_IRQn, 0);
 
-	/* Enable EXTI1 interrupts in NVIC */
-	// Relevant register: NVIC->ISER[0], or use NVIC_EnableIRQ
-	NVIC_EnableIRQ(EXTI0_1_IRQn);
+    /* Enable EXTI1 interrupts in NVIC */
+    // Relevant register: NVIC->ISER[0], or use NVIC_EnableIRQ
+    NVIC_EnableIRQ(EXTI0_1_IRQn);
 }
-
 
 /* This handler is declared in system/src/cmsis/vectors_stm32f0xx.c */
 void TIM2_IRQHandler()
 {
-	/* Check if update interrupt flag is indeed set */
-	if ((TIM2->SR & TIM_SR_UIF) != 0)
-	{
-		trace_printf("\n*** Overflow! ***\n");
+    /* Check if update interrupt flag is indeed set */
+    if ((TIM2->SR & TIM_SR_UIF) != 0) {
+        trace_printf("\n*** Overflow! ***\n");
 
-		/* Clear update interrupt flag */
-		// Relevant register: TIM2->SR
-		TIM2->SR &= ~(TIM_SR_UIF);
+        /* Clear update interrupt flag */
+        // Relevant register: TIM2->SR
+        TIM2->SR &= ~(TIM_SR_UIF);
 
-		/* Restart stopped timer */
-		// Relevant register: TIM2->CR1
-		TIM2->CR1 |= TIM_CR1_CEN;
-	}
+        /* Restart stopped timer */
+        // Relevant register: TIM2->CR1
+        TIM2->CR1 |= TIM_CR1_CEN;
+    }
 }
-
 
 /* This handler is declared in system/src/cmsis/vectors_stm32f0xx.c */
 void EXTI0_1_IRQHandler()
 {
-	/* Check if EXTI1 interrupt pending flag is indeed set */
-	if ((EXTI->PR & EXTI_PR_PR1) != 0)
-	{
-		// timer will be disabled for first edge and enabled on second
-		uint16_t isTimerEnabled = (TIM2->CR1 & TIM_CR1_CEN);
+    /* Check if EXTI1 interrupt pending flag is indeed set */
+    if ((EXTI->PR & EXTI_PR_PR1) != 0) {
+        // timer will be disabled for first edge and enabled on second
+        uint16_t isTimerEnabled = (TIM2->CR1 & TIM_CR1_CEN);
 
-		if (isTimerEnabled) {
-			// stop timer and get count
-			TIM2->CR1 &= ~(TIM_CR1_CEN);
-			uint32_t count = TIM2->CNT;
-			float sigFreq = ((float)SystemCoreClock) / count;
-			float sigPeriod = 1 / sigFreq;
+        if (isTimerEnabled) {
+            // stop timer and get count
+            TIM2->CR1 &= ~(TIM_CR1_CEN);
+            uint32_t count = TIM2->CNT;
+            float sigFreq = ((float) SystemCoreClock) / count;
+            float sigPeriod = 1 / sigFreq;
 
-			trace_printf("Signal Freq:   %f Hz\n", sigFreq);
-			trace_printf("Signal Period: %f s\n\n", sigPeriod);
+            trace_printf("Signal Freq:   %f Hz\n", sigFreq);
+            trace_printf("Signal Period: %f s\n\n", sigPeriod);
 
-		} else {
-			// reset & start timer
-			TIM2->CNT = (uint32_t)0x0;
-			TIM2->CR1 |= TIM_CR1_CEN;
-		}
+        } else {
+            // reset & start timer
+            TIM2->CNT = (uint32_t) 0x0;
+            TIM2->CR1 |= TIM_CR1_CEN;
+        }
 
-		// clear EXTI interrupt pending flag
-		EXTI->PR |= EXTI_PR_PR1;
-	}
+        // clear EXTI interrupt pending flag
+        EXTI->PR |= EXTI_PR_PR1;
+    }
 }
-
 
 #pragma GCC diagnostic pop
 


### PR DESCRIPTION
- Configures GPIOB for use with SPI (PB3 & PB5) and LCD clock (PB4)
- Leaves LCD in 4b mode with clear display, cursor at [1,1]
- Partial implementation of #2

![14801168_10101600813898721_1510844760_n](https://cloud.githubusercontent.com/assets/6734837/19578105/0cb34ade-96cf-11e6-9a6b-1dcdbe8818c0.jpg)
